### PR TITLE
refactor/migrate to informer based structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Build
         run: go build -v ./...
 

--- a/internal/handlers/pod.go
+++ b/internal/handlers/pod.go
@@ -1,6 +1,5 @@
 package handlers
 
-import "C"
 import (
 	"github.com/noisyboy-9/random-k8s-scheduler/internal/config"
 	"github.com/noisyboy-9/random-k8s-scheduler/internal/connector"


### PR DESCRIPTION
- Feat: migrate model.Node.ID to types.UID
- Feat: migrate model.Pod.ID to types.UID
- Feat: Add CRUD for pods in ClusterState
- Feat: Add CRUD for nodes in ClusterState
- Refactor: move cluster_state.go to model module
- Feat: Change Connector to have dynamic client
- Feat: Add node and pod informer handler boilerplate
- Feat: change cluster_state.go to have read/write mutex
- Feat: change consumer to use nodeInformer and podInformer
- chore: run go mod tidy
- Fix: fix problem nodes and pods access is forbidden for service account
- Refactor: unexport Consumer struct
- Feat: implement Stringer interface for model/Node & model/Pod
- Feat: Add EdgeAnnotationKey & EdgeAnnotationValue to scheduler configs
- Feat: Finish implementing nodeInformer
- Refactor: make all fields of model.Pod & model.Node public
- Refactor: remove unnecessary getters for model.Node
- Refactor: remove unnecessary getters for model.Pod
- Fix: import cycle between handlers & consumer
- Feat: make ClusterState thread safe
- Fix: panic error-> assignment to nil map on ClusterState init()
- Refactor: change ClusterState.Pods() & ClusterState.Nodes() to return pointer slice
- Feat: Finish implementing pod handler
- Feat: cleanup
- Feat: update golang version in ci
