### PR TITLE
refactor/migrate to informer based structure

### DIFF
--- a/configs/general.yaml
+++ b/configs/general.yaml
@@ -10,6 +10,8 @@ scheduler:
   namespace: custom-scheduler
   algorithm: "random"
   informerSyncPeriod: "15s"
+  edgeAnnotationKey: "momtaz/cluster-type"
+  edgeAnnotationValue: "edge"
 
 connector:
   mode: "outside"

--- a/internal/model/node.go
+++ b/internal/model/node.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Node struct {
-	ID       types.UID          `json:"id,omitempty"`
-	Name     string             `json:"name,omitempty"`
-	Memory   *resource.Quantity `json:"memory,omitempty"`
-	Cores    *resource.Quantity `json:"cores,omitempty"`
-	IsOnEdge bool               `json:"is_on_edge,omitempty"`
+	ID       types.UID          `json:"id"`
+	Name     string             `json:"name"`
+	Memory   *resource.Quantity `json:"memory"`
+	Cores    *resource.Quantity `json:"cores"`
+	IsOnEdge bool               `json:"is_on_edge"`
 }
 
 func (node *Node) String() string {

--- a/internal/util/node.go
+++ b/internal/util/node.go
@@ -1,10 +1,13 @@
 package util
 
 import (
-	"github.com/noisyboy-9/random-k8s-scheduler/internal/config"
 	"k8s.io/api/core/v1"
+	"k8s.io/utils/strings/slices"
 )
 
+var edgeNodes = []string{"uq7j5k991-01", "uq7g5w631-01", "uq7p7x251-01"}
+
 func IsNodeOnEdge(nodeKubernetesObject *v1.Node) bool {
-	return nodeKubernetesObject.GetAnnotations()[config.Scheduler.EdgeAnnotationKey] == config.Scheduler.EdgeAnnotationValue
+	n := nodeKubernetesObject.GetName()
+	return slices.Contains(edgeNodes, n)
 }


### PR DESCRIPTION
- Feat: migrate model.Node.ID to types.UID
- Feat: migrate model.Pod.ID to types.UID
- Feat: Add CRUD for pods in ClusterState
- Feat: Add CRUD for nodes in ClusterState
- Refactor: move cluster_state.go to model module
- Feat: Change Connector to have dynamic client
- Feat: Add node and pod informer handler boilerplate
- Feat: change cluster_state.go to have read/write mutex
- Feat: change consumer to use nodeInformer and podInformer
- chore: run go mod tidy
- Fix: fix problem nodes and pods access is forbidden for service account
- Refactor: unexport Consumer struct
- Feat: implement Stringer interface for model/Node & model/Pod
- Feat: Add EdgeAnnotationKey & EdgeAnnotationValue to scheduler configs
- Feat: Finish implementing nodeInformer
- Refactor: make all fields of model.Pod & model.Node public
- Refactor: remove unnecessary getters for model.Node
- Refactor: remove unnecessary getters for model.Pod
- Fix: import cycle between handlers & consumer
- Feat: make ClusterState thread safe
- Fix: panic error-> assignment to nil map on ClusterState init()
- Refactor: change ClusterState.Pods() & ClusterState.Nodes() to return pointer slice
- Feat: Finish implementing pod handler
- Feat: cleanup
- Feat: update golang version in ci
- Fix: change edge node detection logic
