### PR TITLE
refactor/migrate to informer based structure

### DIFF
--- a/internal/handlers/node.go
+++ b/internal/handlers/node.go
@@ -19,6 +19,10 @@ func (n NodeEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 		return
 	}
 
+	if nodeKubernetesObject.GetName() == util.MasterNodeName {
+		return
+	}
+
 	node := model.NewNode(
 		nodeKubernetesObject.GetUID(),
 		nodeKubernetesObject.GetName(),

--- a/internal/util/node.go
+++ b/internal/util/node.go
@@ -6,6 +6,7 @@ import (
 )
 
 var edgeNodes = []string{"uq7j5k991-01", "uq7g5w631-01", "uq7p7x251-01"}
+var MasterNodeName = "uq7g5t611-01"
 
 func IsNodeOnEdge(nodeKubernetesObject *v1.Node) bool {
 	n := nodeKubernetesObject.GetName()


### PR DESCRIPTION
- Feat: migrate model.Node.ID to types.UID
- Feat: migrate model.Pod.ID to types.UID
- Feat: Add CRUD for pods in ClusterState
- Feat: Add CRUD for nodes in ClusterState
- Refactor: move cluster_state.go to model module
- Feat: Change Connector to have dynamic client
- Feat: Add node and pod informer handler boilerplate
- Feat: change cluster_state.go to have read/write mutex
- Feat: change consumer to use nodeInformer and podInformer
- chore: run go mod tidy
- Fix: fix problem nodes and pods access is forbidden for service account
- Refactor: unexport Consumer struct
- Feat: implement Stringer interface for model/Node & model/Pod
- Feat: Add EdgeAnnotationKey & EdgeAnnotationValue to scheduler configs
- Feat: Finish implementing nodeInformer
- Refactor: make all fields of model.Pod & model.Node public
- Refactor: remove unnecessary getters for model.Node
- Refactor: remove unnecessary getters for model.Pod
- Fix: import cycle between handlers & consumer
- Feat: make ClusterState thread safe
- Fix: panic error-> assignment to nil map on ClusterState init()
- Refactor: change ClusterState.Pods() & ClusterState.Nodes() to return pointer slice
- Feat: Finish implementing pod handler
- Feat: cleanup
- Feat: update golang version in ci
- Fix: change edge node detection logic
- Feat: exclude master node
