### PR TITLE
fix/fix scheduler bugs

### DIFF
--- a/configs/general.yaml
+++ b/configs/general.yaml
@@ -15,5 +15,5 @@ scheduler:
 
 connector:
   mode: "outside"
-  masterURL: "192.168.76.2"
+  masterURL: "172.20.2.4"
   kubeConfigPath: "/Users/sinashariati/.kube/config"

--- a/configs/general.yaml
+++ b/configs/general.yaml
@@ -6,9 +6,9 @@ logging:
   level: "debug"
 
 scheduler:
-  name: custom-scheduler
-  namespace: custom-scheduler
-  algorithm: "random"
+  name: random-scheduler
+  namespace: random-scheduler
+  algorithm: "cloud-first"
   informerSyncPeriod: "15s"
   edgeAnnotationKey: "momtaz/cluster-type"
   edgeAnnotationValue: "edge"

--- a/internal/handlers/node.go
+++ b/internal/handlers/node.go
@@ -27,6 +27,11 @@ func (n NodeEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 		util.IsNodeOnEdge(nodeKubernetesObject),
 	)
 
+	if util.IsMasterNode(node) {
+		log.App.WithFields(logrus.Fields{"node": node}).Info("found master node. Don't add this node to scheduling pool")
+		return
+	}
+
 	n.State.AddNode(node)
 
 	log.App.WithFields(logrus.Fields{

--- a/internal/handlers/pod.go
+++ b/internal/handlers/pod.go
@@ -48,6 +48,7 @@ func (p PodEventHandler) OnAdd(obj interface{}, _ bool) {
 
 	if err = connector.C.BindPodToNode(pod, selectedNode); err != nil {
 		log.App.WithError(err).Error("error in binding pod to node")
+		return
 	}
 
 	p.State.SaveSelectedNodeForPod(selectedNode, pod)
@@ -133,10 +134,8 @@ func (p PodEventHandler) OnDelete(obj interface{}) {
 		log.App.WithField("pod", deletedPod).Error("trying to delete pod that doesn't exist")
 	}
 
-	node, exist := p.State.GetSelectedNodeForPod(deletedPod)
-	if !exist {
-		log.App.WithField("pod", deletedPod).Panic("trying to deleted pod which is not owned")
-	}
+	node := p.State.GetSelectedNodeForPod(deletedPod)
+
 	p.State.DeAllocateResources(node, deletedPod)
 	p.State.RemovePod(deletedPod)
 

--- a/internal/model/cluster_state.go
+++ b/internal/model/cluster_state.go
@@ -89,10 +89,9 @@ func (s *ClusterState) GetNodeWithID(id types.UID) (node *Node, exists bool) {
 
 func (s *ClusterState) Nodes() []*Node {
 	nodes := make([]*Node, 0, len(s.nodes))
-	i := 0
+
 	for _, n := range s.nodes {
 		nodes = append(nodes, n)
-		i++
 	}
 
 	return nodes

--- a/internal/util/node.go
+++ b/internal/util/node.go
@@ -1,13 +1,19 @@
 package util
 
 import (
+	"github.com/noisyboy-9/random-k8s-scheduler/internal/model"
 	"k8s.io/api/core/v1"
 	"k8s.io/utils/strings/slices"
 )
 
 var edgeNodes = []string{"uq7j5k991-01", "uq7g5w631-01", "uq7p7x251-01"}
+var masterNodeName = "uq7g5t611-01"
 
 func IsNodeOnEdge(nodeKubernetesObject *v1.Node) bool {
 	n := nodeKubernetesObject.GetName()
 	return slices.Contains(edgeNodes, n)
+}
+
+func IsMasterNode(node *model.Node) bool {
+	return node.Name == masterNodeName
 }


### PR DESCRIPTION
- Feat: migrate model.Node.ID to types.UID
- Feat: migrate model.Pod.ID to types.UID
- Feat: Add CRUD for pods in ClusterState
- Feat: Add CRUD for nodes in ClusterState
- Refactor: move cluster_state.go to model module
- Feat: Change Connector to have dynamic client
- Feat: Add node and pod informer handler boilerplate
- Feat: change cluster_state.go to have read/write mutex
- Feat: change consumer to use nodeInformer and podInformer
- chore: run go mod tidy
- Fix: fix problem nodes and pods access is forbidden for service account
- Refactor: unexport Consumer struct
- Feat: implement Stringer interface for model/Node & model/Pod
- Feat: Add EdgeAnnotationKey & EdgeAnnotationValue to scheduler configs
- Feat: Finish implementing nodeInformer
- Refactor: make all fields of model.Pod & model.Node public
- Refactor: remove unnecessary getters for model.Node
- Refactor: remove unnecessary getters for model.Pod
- Fix: import cycle between handlers & consumer
- Feat: make ClusterState thread safe
- Fix: panic error-> assignment to nil map on ClusterState init()
- Refactor: change ClusterState.Pods() & ClusterState.Nodes() to return pointer slice
- Feat: Finish implementing pod handler
- Feat: cleanup
- Feat: update golang version in ci
- Fix: change edge node detection logic
- Feat: change masterURL config to simorgh.cloud cluster
- Refactor: remove unnecessary counter
- Feat: add logic to detect master node and prevent it from entering scheduling pool
- Fix: in case of bind error resource model is diverging
- Fix: node deletion may result in panic
