### PR TITLE
BugFix: cluster state not being tracked correctly

### DIFF
--- a/cmd/schedule.go
+++ b/cmd/schedule.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/noisyboy-9/sencillo/internal/app"
 	"github.com/spf13/cobra"
+
+	"github.com/noisyboy-9/sencillo/internal/app"
 )
 
 // scheduleCmd represents the schedule command

--- a/internal/config/scheduler.go
+++ b/internal/config/scheduler.go
@@ -3,12 +3,10 @@ package config
 import "time"
 
 type scheduler struct {
-	Name                string        `json:"name"`
-	InformerSyncPeriod  time.Duration `json:"informerSyncPeriod"`
-	Namespace           string        `json:"namespace"`
-	Algorithm           string        `json:"algorithm"`
-	EdgeAnnotationKey   string        `json:"edgeAnnotationKey"`
-	EdgeAnnotationValue string        `json:"edgeAnnotationValue"`
+	Name               string        `json:"name"`
+	InformerSyncPeriod time.Duration `json:"informerSyncPeriod"`
+	Namespace          string        `json:"namespace"`
+	Algorithm          string        `json:"algorithm"`
 }
 
 var Scheduler *scheduler

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -28,8 +28,6 @@ func Connect() {
 	log.App.Info("connecting to Kubernetes cluster ...")
 	C = new(connector)
 
-	log.App.Info(config.Connector.Mode)
-
 	var err error
 	if config.Connector.Mode == "outside" {
 		C.client, err = createOutsideClusterClient()
@@ -38,7 +36,7 @@ func Connect() {
 			return
 		}
 
-		log.App.Info("successfully connected to Kubernetes cluster")
+		log.App.WithField("mode", config.Connector.Mode).Info("successfully connected to Kubernetes cluster")
 		return
 	}
 
@@ -48,7 +46,7 @@ func Connect() {
 		return
 	}
 
-	log.App.Info("successfully connected to Kubernetes cluster")
+	log.App.WithField("mode", config.Connector.Mode).Info("successfully connected to Kubernetes cluster")
 }
 
 func createInClusterClient() (*kubernetes.Clientset, error) {

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -5,14 +5,15 @@ import (
 	"os"
 	"os/signal"
 
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/noisyboy-9/sencillo/internal/config"
 	"github.com/noisyboy-9/sencillo/internal/connector"
 	"github.com/noisyboy-9/sencillo/internal/handlers"
 	"github.com/noisyboy-9/sencillo/internal/log"
 	"github.com/noisyboy-9/sencillo/internal/model"
 	"github.com/noisyboy-9/sencillo/internal/scheduler"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
 )
 
 type consumer struct {
@@ -51,8 +52,8 @@ func Start() {
 	}
 
 	go nodeInformer.Run(ctx.Done())
-	go podInformer.Run(ctx.Done())
+	cache.WaitForCacheSync(ctx.Done(), nodeInformer.HasSynced)
 
-	C.State.SetIsNodesSynced(cache.WaitForCacheSync(ctx.Done(), nodeInformer.HasSynced))
+	go podInformer.Run(ctx.Done())
 	<-ctx.Done()
 }

--- a/internal/handlers/node.go
+++ b/internal/handlers/node.go
@@ -26,6 +26,7 @@ func (n NodeEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 		nodeKubernetesObject.Status.Allocatable.Memory(),
 		nodeKubernetesObject.Status.Allocatable.Cpu(),
 		util.IsNodeOnEdge(nodeKubernetesObject),
+		util.IsMasterNode(nodeKubernetesObject),
 	)
 
 	n.State.AddNode(node)

--- a/internal/handlers/node.go
+++ b/internal/handlers/node.go
@@ -14,19 +14,19 @@ type NodeEventHandler struct {
 }
 
 func (n NodeEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
-	nodeKubernetesObject, ok := obj.(*v1.Node)
+	kubeNode, ok := obj.(*v1.Node)
 	if !ok {
 		log.App.Panic("unexpected event object type")
 		return
 	}
 
 	node := model.NewNode(
-		nodeKubernetesObject.GetUID(),
-		nodeKubernetesObject.GetName(),
-		nodeKubernetesObject.Status.Allocatable.Memory(),
-		nodeKubernetesObject.Status.Allocatable.Cpu(),
-		util.IsNodeOnEdge(nodeKubernetesObject),
-		util.IsMasterNode(nodeKubernetesObject),
+		kubeNode.GetUID(),
+		kubeNode.GetName(),
+		kubeNode.Status.Allocatable.Cpu(),
+		kubeNode.Status.Allocatable.Memory(),
+		util.IsNodeOnEdge(kubeNode),
+		util.IsMasterNode(kubeNode),
 	)
 
 	n.State.Lock()

--- a/internal/handlers/node.go
+++ b/internal/handlers/node.go
@@ -29,7 +29,9 @@ func (n NodeEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 		util.IsMasterNode(nodeKubernetesObject),
 	)
 
+	n.State.Lock()
 	n.State.AddNode(node)
+	n.State.Unlock()
 
 	log.App.WithFields(logrus.Fields{
 		"node":         node,

--- a/internal/handlers/node.go
+++ b/internal/handlers/node.go
@@ -1,11 +1,12 @@
 package handlers
 
 import (
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/noisyboy-9/sencillo/internal/log"
 	"github.com/noisyboy-9/sencillo/internal/model"
 	"github.com/noisyboy-9/sencillo/internal/util"
-	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
 )
 
 type NodeEventHandler struct {
@@ -36,63 +37,9 @@ func (n NodeEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 }
 
 func (n NodeEventHandler) OnUpdate(oldObj interface{}, newObj interface{}) {
-	oldNodeKubernetesObj, ok := oldObj.(*v1.Node)
-	if !ok {
-		log.App.Panic("unexpected event object type")
-		return
-	}
-	newNodeKubernetesObj, ok := newObj.(*v1.Node)
-	if !ok {
-		log.App.Panic("unexpected event object type")
-		return
-	}
-
-	oldNode := model.NewNode(
-		oldNodeKubernetesObj.GetUID(),
-		oldNodeKubernetesObj.GetName(),
-		oldNodeKubernetesObj.Status.Allocatable.Memory(),
-		oldNodeKubernetesObj.Status.Allocatable.Cpu(),
-		util.IsNodeOnEdge(oldNodeKubernetesObj),
-	)
-
-	newNode := model.NewNode(
-		newNodeKubernetesObj.GetUID(),
-		newNodeKubernetesObj.GetName(),
-		newNodeKubernetesObj.Status.Allocatable.Memory(),
-		newNodeKubernetesObj.Status.Allocatable.Cpu(),
-		util.IsNodeOnEdge(newNodeKubernetesObj),
-	)
-
-	if newNode.Cores.Equal(*oldNode.Cores) && newNode.Memory.Equal(*oldNode.Memory) {
-		return
-	}
-
-	err := n.State.EditNodeWithUID(oldNode.ID, newNode)
-	if err != nil {
-		log.App.WithError(err).Error("error in updating with UID")
-	}
-
-	log.App.WithFields(logrus.Fields{
-		"old_node": oldNode,
-		"new_node": newNode,
-	}).Info("updated node status")
+	return
 }
 
 func (n NodeEventHandler) OnDelete(obj interface{}) {
-	deletedNodeKubernetesObject, ok := obj.(*v1.Node)
-	if !ok {
-		log.App.Panic("unexpected event object type")
-		return
-	}
-
-	node := model.NewNode(
-		deletedNodeKubernetesObject.GetUID(),
-		deletedNodeKubernetesObject.GetName(),
-		deletedNodeKubernetesObject.Status.Allocatable.Memory(),
-		deletedNodeKubernetesObject.Status.Allocatable.Cpu(),
-		util.IsNodeOnEdge(deletedNodeKubernetesObject),
-	)
-
-	n.State.RemoveNode(node)
-	log.App.WithField("node", node).Info("deleted node")
+	return
 }

--- a/internal/model/cluster_state.go
+++ b/internal/model/cluster_state.go
@@ -1,139 +1,67 @@
 package model
 
 import (
-	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type ClusterState struct {
-	mux           *sync.RWMutex
-	nodes         map[types.UID]*Node
-	isNodesSynced bool
-	pods          map[types.UID]*Pod
-	placement     map[*Pod]*Node
+	sync.Mutex
+
+	Nodes         []Node
+	AllocationMap map[Node][]Pod
 }
 
 func NewClusterState() *ClusterState {
 	return &ClusterState{
-		mux:       new(sync.RWMutex),
-		nodes:     make(map[types.UID]*Node),
-		pods:      make(map[types.UID]*Pod),
-		placement: make(map[*Pod]*Node),
+		Nodes:         make([]Node, 0),
+		AllocationMap: make(map[Node][]Pod),
 	}
 }
 
-func (s *ClusterState) IsNodesSynced() bool {
-	s.mux.RLock()
-	defer s.mux.RUnlock()
-	return s.isNodesSynced
+func (state *ClusterState) AddNode(node Node) {
+	state.Lock()
+	defer state.Unlock()
+
+	state.Nodes = append(state.Nodes, node)
 }
 
-func (s *ClusterState) SetIsNodesSynced(isNodesSynced bool) {
-	s.mux.Lock()
-	defer s.mux.Unlock()
-	s.isNodesSynced = isNodesSynced
-}
-
-func (s *ClusterState) AddPod(p *Pod) {
-	s.pods[p.ID] = p
-}
-
-func (s *ClusterState) RemovePod(p *Pod) {
-	delete(s.pods, p.ID)
-	delete(s.placement, p)
-}
-func (s *ClusterState) RemovePodByID(id types.UID) {
-	delete(s.pods, id)
-}
-
-func (s *ClusterState) EditPodWithUID(id types.UID, edited *Pod) error {
-	if _, ok := s.pods[id]; !ok {
-		return errors.New("pod with given uid doesn't exist")
-	}
-
-	s.pods[id] = edited
-	return nil
-}
-
-func (s *ClusterState) GetPodByUID(id types.UID) (pod *Pod, exists bool) {
-	pod, exists = s.pods[id]
-	return
-}
-
-func (s *ClusterState) AddNode(n *Node) {
-	s.nodes[n.ID] = n
-}
-
-func (s *ClusterState) RemoveNode(n *Node) {
-	delete(s.nodes, n.ID)
-}
-
-func (s *ClusterState) RemoveNodeByID(id types.UID) {
-	delete(s.nodes, id)
-}
-
-func (s *ClusterState) EditNodeWithUID(id types.UID, edited *Node) error {
-	if _, ok := s.nodes[id]; !ok {
-		return errors.New("node with given id doesn't exist")
-	}
-
-	s.nodes[id] = edited
-	return nil
-}
-func (s *ClusterState) GetNodeWithID(id types.UID) (node *Node, exists bool) {
-	node, exists = s.nodes[id]
-	return
-}
-
-func (s *ClusterState) Nodes() []*Node {
-	nodes := make([]*Node, 0, len(s.nodes))
-	i := 0
-	for _, n := range s.nodes {
-		nodes = append(nodes, n)
-		i++
-	}
-
-	return nodes
-}
-
-func (s *ClusterState) Pods() []*Pod {
-	pods := make([]*Pod, 0, len(s.pods))
-	i := 0
-	for _, p := range s.pods {
-		pods = append(pods, p)
-		i++
-	}
-
-	return pods
-}
-
-func (s *ClusterState) AllocateResources(node *Node, pod *Pod) {
-	node.allocateCpu(*pod.Cores)
-	node.allocateMemory(*pod.Memory)
-}
-
-func (s *ClusterState) DeAllocateResources(node *Node, pod *Pod) {
-	node.deAllocateCpu(*pod.Cores)
-	node.deallocateMemory(*pod.Memory)
-}
-
-func (s *ClusterState) SaveSelectedNodeForPod(selectedNode *Node, pod *Pod) {
-	s.placement[pod] = selectedNode
-}
-
-func (s *ClusterState) GetSelectedNodeForPod(pod *Pod) (n *Node, exist bool) {
-	n, exist = s.placement[pod]
-	return
-}
-
-func (s *ClusterState) FindNodeByName(name string) (n *Node, err error) {
-	for _, node := range s.nodes {
-		if node.Name == name {
+func (state *ClusterState) findNodeByName(nodeName string) (Node, error) {
+	for _, node := range state.Nodes {
+		if node.Name == nodeName {
 			return node, nil
 		}
 	}
 
-	return nil, errors.New(fmt.Sprintf("node with name: %s can't be found", name))
+	return Node{}, fmt.Errorf("node: %s not found", nodeName)
+}
+
+func (state *ClusterState) Sync(podList []Pod) error {
+	for _, pod := range podList {
+		if pod.NodeName == "" {
+			// The pod is currently unscheduled, it will be scheduled later.
+			continue
+		}
+
+		node, err := state.findNodeByName(pod.NodeName)
+		if err != nil {
+			return err
+		}
+
+		state.AllocationMap[node] = append(state.AllocationMap[node], pod)
+	}
+
+	for node, pods := range state.AllocationMap {
+		node.Cores = resource.NewQuantity(0.0, resource.DecimalSI)
+		node.Memory = resource.NewQuantity(0.0, resource.BinarySI)
+
+		for _, pod := range pods {
+			node.Memory.Add(pod.Memory.DeepCopy())
+			node.Cores.Add(pod.Cores.DeepCopy())
+		}
+	}
+
+	return nil
 }

--- a/internal/model/cluster_state.go
+++ b/internal/model/cluster_state.go
@@ -22,9 +22,6 @@ func NewClusterState() *ClusterState {
 }
 
 func (state *ClusterState) AddNode(node Node) {
-	state.Lock()
-	defer state.Unlock()
-
 	state.Nodes = append(state.Nodes, node)
 }
 

--- a/internal/model/node.go
+++ b/internal/model/node.go
@@ -1,11 +1,12 @@
 package model
 
 import (
-	"github.com/noisyboy-9/sencillo/internal/log"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/noisyboy-9/sencillo/internal/log"
 )
 
 type Node struct {
@@ -24,8 +25,8 @@ func (node *Node) String() string {
 	return string(j)
 }
 
-func NewNode(id types.UID, name string, memory *resource.Quantity, cpu *resource.Quantity, isOnEdge bool) *Node {
-	return &Node{
+func NewNode(id types.UID, name string, memory *resource.Quantity, cpu *resource.Quantity, isOnEdge bool) Node {
+	return Node{
 		ID:       id,
 		Name:     name,
 		Memory:   memory,
@@ -34,7 +35,7 @@ func NewNode(id types.UID, name string, memory *resource.Quantity, cpu *resource
 	}
 }
 
-func (node *Node) HasEnoughResourcesForPod(pod *Pod) bool {
+func (node *Node) HasEnoughResourcesForPod(pod Pod) bool {
 	reducedNodeCores := &resource.Quantity{}
 	reducedNodeMemory := &resource.Quantity{}
 
@@ -65,27 +66,4 @@ func (node *Node) HasEnoughResourcesForPod(pod *Pod) bool {
 	}
 
 	return hasCpu && hasMemory
-}
-func (node *Node) SetMemory(memory *resource.Quantity) {
-	node.Memory = memory
-}
-
-func (node *Node) SetCores(cores *resource.Quantity) {
-	node.Cores = cores
-}
-
-func (node *Node) allocateMemory(memory resource.Quantity) {
-	node.Memory.Sub(memory)
-}
-
-func (node *Node) allocateCpu(cpu resource.Quantity) {
-	node.Cores.Sub(cpu)
-}
-
-func (node *Node) deallocateMemory(memory resource.Quantity) {
-	node.Memory.Add(memory)
-}
-
-func (node *Node) deAllocateCpu(cpu resource.Quantity) {
-	node.Cores.Add(cpu)
 }

--- a/internal/model/node.go
+++ b/internal/model/node.go
@@ -4,7 +4,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/noisyboy-9/sencillo/internal/log"
 )
@@ -18,15 +17,7 @@ type Node struct {
 	IsMaster bool               `json:"is_master"`
 }
 
-func (node *Node) String() string {
-	j, err := json.Marshal(node)
-	if err != nil {
-		log.App.WithError(err).Info("error in marshaling model.Node")
-	}
-	return string(j)
-}
-
-func NewNode(id types.UID, name string, memory *resource.Quantity, cpu *resource.Quantity, isOnEdge bool, isMaster bool) Node {
+func NewNode(id types.UID, name string, cpu *resource.Quantity, memory *resource.Quantity, isOnEdge bool, isMaster bool) Node {
 	return Node{
 		ID:       id,
 		Name:     name,

--- a/internal/model/node.go
+++ b/internal/model/node.go
@@ -15,6 +15,7 @@ type Node struct {
 	Memory   *resource.Quantity `json:"memory"`
 	Cores    *resource.Quantity `json:"cores"`
 	IsOnEdge bool               `json:"is_on_edge"`
+	IsMaster bool               `json:"is_master"`
 }
 
 func (node *Node) String() string {
@@ -25,13 +26,14 @@ func (node *Node) String() string {
 	return string(j)
 }
 
-func NewNode(id types.UID, name string, memory *resource.Quantity, cpu *resource.Quantity, isOnEdge bool) Node {
+func NewNode(id types.UID, name string, memory *resource.Quantity, cpu *resource.Quantity, isOnEdge bool, isMaster bool) Node {
 	return Node{
 		ID:       id,
 		Name:     name,
 		Memory:   memory,
 		Cores:    cpu,
 		IsOnEdge: isOnEdge,
+		IsMaster: isMaster,
 	}
 }
 

--- a/internal/model/pod.go
+++ b/internal/model/pod.go
@@ -1,19 +1,24 @@
 package model
 
 import (
-	"github.com/noisyboy-9/sencillo/internal/log"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/noisyboy-9/sencillo/internal/log"
 )
 
 type Pod struct {
-	ID        types.UID `json:"id,omitempty"`
-	Name      string    `json:"name,omitempty"`
-	Namespace string    `json:"namespace,omitempty"`
+	ID        types.UID          `json:"id,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	Namespace string             `json:"namespace,omitempty"`
+	NodeName  string             `json:"nodeName,omitempty"`
+	Cores     *resource.Quantity `json:"cores,omitempty"`
+	Memory    *resource.Quantity `json:"memory,omitempty"`
+}
 
-	Cores  *resource.Quantity `json:"cores,omitempty"`
-	Memory *resource.Quantity `json:"memory,omitempty"`
+func NewPod(ID types.UID, name string, namespace string, nodeName string, cores *resource.Quantity, memory *resource.Quantity) Pod {
+	return Pod{ID: ID, Name: name, Namespace: namespace, NodeName: nodeName, Cores: cores, Memory: memory}
 }
 
 func (pod *Pod) String() string {
@@ -22,14 +27,4 @@ func (pod *Pod) String() string {
 		log.App.WithError(err).Panic("can't marshal node")
 	}
 	return string(j)
-}
-
-func NewPod(id types.UID, name string, namespace string, cpu *resource.Quantity, memory *resource.Quantity) *Pod {
-	return &Pod{
-		ID:        id,
-		Name:      name,
-		Namespace: namespace,
-		Cores:     cpu,
-		Memory:    memory,
-	}
 }

--- a/internal/model/pod.go
+++ b/internal/model/pod.go
@@ -3,9 +3,6 @@ package model
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
-
-	"github.com/noisyboy-9/sencillo/internal/log"
 )
 
 type Pod struct {
@@ -19,12 +16,4 @@ type Pod struct {
 
 func NewPod(ID types.UID, name string, namespace string, nodeName string, cores *resource.Quantity, memory *resource.Quantity) Pod {
 	return Pod{ID: ID, Name: name, Namespace: namespace, NodeName: nodeName, Cores: cores, Memory: memory}
-}
-
-func (pod *Pod) String() string {
-	j, err := json.Marshal(pod)
-	if err != nil {
-		log.App.WithError(err).Panic("can't marshal node")
-	}
-	return string(j)
 }

--- a/internal/scheduler/cloud-first/cloud-first.go
+++ b/internal/scheduler/cloud-first/cloud-first.go
@@ -26,12 +26,12 @@ func (c CloudFirstScheduler) Filter(pod model.Pod, nodes []model.Node) (eligible
 			continue
 		}
 
-		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
-			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
-		}
-
-		if node.HasEnoughResourcesForPod(pod) && !node.IsOnEdge {
-			eligibleCloudNodes = append(eligibleCloudNodes, node)
+		if node.HasEnoughResourcesForPod(pod) {
+			if node.IsOnEdge {
+				eligibleEdgeNodes = append(eligibleEdgeNodes, node)
+			} else {
+				eligibleCloudNodes = append(eligibleCloudNodes, node)
+			}
 		}
 	}
 

--- a/internal/scheduler/cloud-first/cloud-first.go
+++ b/internal/scheduler/cloud-first/cloud-first.go
@@ -10,17 +10,17 @@ import (
 
 type CloudFirstScheduler struct{}
 
-func (c CloudFirstScheduler) Run(pod *model.Pod, nodes []*model.Node) (node *model.Node, err error) {
+func (c CloudFirstScheduler) Run(pod model.Pod, nodes []model.Node) (node model.Node, err error) {
 	edgeNodes, cloudNodes := c.Filter(pod, nodes)
 	if len(edgeNodes) == 0 && len(cloudNodes) == 0 {
-		return nil, errors.New("no eligible nodes found")
+		return model.Node{}, errors.New("no eligible nodes found")
 
 	}
 	return c.Schedule(edgeNodes, cloudNodes), nil
 }
-func (c CloudFirstScheduler) Filter(pod *model.Pod, nodes []*model.Node) (eligibleEdgeNodes []*model.Node, eligibleCloudNodes []*model.Node) {
-	eligibleEdgeNodes = make([]*model.Node, 0)
-	eligibleCloudNodes = make([]*model.Node, 0)
+func (c CloudFirstScheduler) Filter(pod model.Pod, nodes []model.Node) (eligibleEdgeNodes []model.Node, eligibleCloudNodes []model.Node) {
+	eligibleEdgeNodes = make([]model.Node, 0)
+	eligibleCloudNodes = make([]model.Node, 0)
 	for _, node := range nodes {
 		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
 			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
@@ -34,7 +34,7 @@ func (c CloudFirstScheduler) Filter(pod *model.Pod, nodes []*model.Node) (eligib
 	return eligibleEdgeNodes, eligibleCloudNodes
 }
 
-func (c CloudFirstScheduler) Schedule(edgeNodes []*model.Node, cloudNodes []*model.Node) (node *model.Node) {
+func (c CloudFirstScheduler) Schedule(edgeNodes []model.Node, cloudNodes []model.Node) (node model.Node) {
 	if len(cloudNodes) != 0 {
 		return cloudNodes[rand.Intn(len(cloudNodes))]
 	}

--- a/internal/scheduler/cloud-first/cloud-first.go
+++ b/internal/scheduler/cloud-first/cloud-first.go
@@ -22,6 +22,10 @@ func (c CloudFirstScheduler) Filter(pod model.Pod, nodes []model.Node) (eligible
 	eligibleEdgeNodes = make([]model.Node, 0)
 	eligibleCloudNodes = make([]model.Node, 0)
 	for _, node := range nodes {
+		if node.IsMaster {
+			continue
+		}
+
 		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
 			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
 		}

--- a/internal/scheduler/edge-first/biggest_fitting.go
+++ b/internal/scheduler/edge-first/biggest_fitting.go
@@ -23,6 +23,10 @@ func (b BiggestFittingEdgeNodeScheduler) Filter(pod model.Pod, nodes []model.Nod
 	eligibleEdgeNodes = make([]model.Node, 0)
 	eligibleCloudNodes = make([]model.Node, 0)
 	for _, node := range nodes {
+		if node.IsMaster {
+			continue
+		}
+
 		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
 			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
 		}

--- a/internal/scheduler/edge-first/biggest_fitting.go
+++ b/internal/scheduler/edge-first/biggest_fitting.go
@@ -11,17 +11,17 @@ import (
 
 type BiggestFittingEdgeNodeScheduler struct{}
 
-func (b BiggestFittingEdgeNodeScheduler) Run(pod *model.Pod, nodes []*model.Node) (node *model.Node, err error) {
+func (b BiggestFittingEdgeNodeScheduler) Run(pod model.Pod, nodes []model.Node) (node model.Node, err error) {
 	edgeNodes, cloudNodes := b.Filter(pod, nodes)
 	if len(edgeNodes) == 0 && len(cloudNodes) == 0 {
-		return nil, errors.New("no eligible nodes found")
+		return model.Node{}, errors.New("no eligible nodes found")
 	}
 	return b.Schedule(edgeNodes, cloudNodes), nil
 }
 
-func (b BiggestFittingEdgeNodeScheduler) Filter(pod *model.Pod, nodes []*model.Node) (eligibleEdgeNodes []*model.Node, eligibleCloudNodes []*model.Node) {
-	eligibleEdgeNodes = make([]*model.Node, 0)
-	eligibleCloudNodes = make([]*model.Node, 0)
+func (b BiggestFittingEdgeNodeScheduler) Filter(pod model.Pod, nodes []model.Node) (eligibleEdgeNodes []model.Node, eligibleCloudNodes []model.Node) {
+	eligibleEdgeNodes = make([]model.Node, 0)
+	eligibleCloudNodes = make([]model.Node, 0)
 	for _, node := range nodes {
 		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
 			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
@@ -34,7 +34,8 @@ func (b BiggestFittingEdgeNodeScheduler) Filter(pod *model.Pod, nodes []*model.N
 
 	return eligibleEdgeNodes, eligibleCloudNodes
 }
-func (b BiggestFittingEdgeNodeScheduler) Schedule(edgeNodes []*model.Node, cloudNodes []*model.Node) (node *model.Node) {
+
+func (b BiggestFittingEdgeNodeScheduler) Schedule(edgeNodes []model.Node, cloudNodes []model.Node) (node model.Node) {
 	if len(edgeNodes) != 0 {
 		return util.FindLargestNode(edgeNodes)
 	}

--- a/internal/scheduler/edge-first/biggest_fitting.go
+++ b/internal/scheduler/edge-first/biggest_fitting.go
@@ -27,12 +27,12 @@ func (b BiggestFittingEdgeNodeScheduler) Filter(pod model.Pod, nodes []model.Nod
 			continue
 		}
 
-		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
-			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
-		}
-
-		if node.HasEnoughResourcesForPod(pod) && !node.IsOnEdge {
-			eligibleCloudNodes = append(eligibleCloudNodes, node)
+		if node.HasEnoughResourcesForPod(pod) {
+			if node.IsOnEdge {
+				eligibleEdgeNodes = append(eligibleEdgeNodes, node)
+			} else {
+				eligibleCloudNodes = append(eligibleCloudNodes, node)
+			}
 		}
 	}
 

--- a/internal/scheduler/edge-first/smallest_fitting.go
+++ b/internal/scheduler/edge-first/smallest_fitting.go
@@ -28,12 +28,12 @@ func (s SmallestFittingEdgeNodeScheduler) Filter(pod model.Pod, nodes []model.No
 			continue
 		}
 
-		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
-			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
-		}
-
-		if node.HasEnoughResourcesForPod(pod) && !node.IsOnEdge {
-			eligibleCloudNodes = append(eligibleCloudNodes, node)
+		if node.HasEnoughResourcesForPod(pod) {
+			if node.IsOnEdge {
+				eligibleEdgeNodes = append(eligibleEdgeNodes, node)
+			} else {
+				eligibleCloudNodes = append(eligibleCloudNodes, node)
+			}
 		}
 	}
 

--- a/internal/scheduler/edge-first/smallest_fitting.go
+++ b/internal/scheduler/edge-first/smallest_fitting.go
@@ -24,6 +24,10 @@ func (s SmallestFittingEdgeNodeScheduler) Filter(pod model.Pod, nodes []model.No
 	eligibleEdgeNodes = make([]model.Node, 0)
 	eligibleCloudNodes = make([]model.Node, 0)
 	for _, node := range nodes {
+		if node.IsMaster {
+			continue
+		}
+
 		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
 			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
 		}

--- a/internal/scheduler/edge-first/smallest_fitting.go
+++ b/internal/scheduler/edge-first/smallest_fitting.go
@@ -12,17 +12,17 @@ import (
 
 type SmallestFittingEdgeNodeScheduler struct{}
 
-func (s SmallestFittingEdgeNodeScheduler) Run(pod *model.Pod, nodes []*model.Node) (node *model.Node, err error) {
+func (s SmallestFittingEdgeNodeScheduler) Run(pod model.Pod, nodes []model.Node) (node model.Node, err error) {
 	edgeNodes, cloudNodes := s.Filter(pod, nodes)
 	if len(edgeNodes) == 0 && len(cloudNodes) == 0 {
-		return nil, errors.New("no eligible nodes found")
+		return model.Node{}, errors.New("no eligible nodes found")
 	}
 	return s.Schedule(edgeNodes, cloudNodes), nil
 }
 
-func (s SmallestFittingEdgeNodeScheduler) Filter(pod *model.Pod, nodes []*model.Node) (eligibleEdgeNodes []*model.Node, eligibleCloudNodes []*model.Node) {
-	eligibleEdgeNodes = make([]*model.Node, 0)
-	eligibleCloudNodes = make([]*model.Node, 0)
+func (s SmallestFittingEdgeNodeScheduler) Filter(pod model.Pod, nodes []model.Node) (eligibleEdgeNodes []model.Node, eligibleCloudNodes []model.Node) {
+	eligibleEdgeNodes = make([]model.Node, 0)
+	eligibleCloudNodes = make([]model.Node, 0)
 	for _, node := range nodes {
 		if node.HasEnoughResourcesForPod(pod) && node.IsOnEdge {
 			eligibleEdgeNodes = append(eligibleEdgeNodes, node)
@@ -35,7 +35,8 @@ func (s SmallestFittingEdgeNodeScheduler) Filter(pod *model.Pod, nodes []*model.
 
 	return eligibleEdgeNodes, eligibleCloudNodes
 }
-func (s SmallestFittingEdgeNodeScheduler) Schedule(edgeNodes []*model.Node, cloudNodes []*model.Node) (node *model.Node) {
+
+func (s SmallestFittingEdgeNodeScheduler) Schedule(edgeNodes []model.Node, cloudNodes []model.Node) (node model.Node) {
 	if len(edgeNodes) != 0 {
 		return util.FindSmallestNode(edgeNodes)
 	}

--- a/internal/scheduler/random/random.go
+++ b/internal/scheduler/random/random.go
@@ -20,6 +20,10 @@ func (r RandScheduler) Run(pod model.Pod, nodes []model.Node) (node model.Node, 
 func (r RandScheduler) Filter(pod model.Pod, nodes []model.Node) []model.Node {
 	eligibleNodes := make([]model.Node, 0)
 	for _, node := range nodes {
+		if node.IsMaster {
+			continue
+		}
+
 		if node.HasEnoughResourcesForPod(pod) {
 			eligibleNodes = append(eligibleNodes, node)
 		}

--- a/internal/scheduler/random/random.go
+++ b/internal/scheduler/random/random.go
@@ -9,24 +9,25 @@ import (
 
 type RandScheduler struct{}
 
-func (r RandScheduler) Run(pod *model.Pod, nodes []*model.Node) (node *model.Node, err error) {
+func (r RandScheduler) Run(pod model.Pod, nodes []model.Node) (node model.Node, err error) {
 	eligibleNodes := r.Filter(pod, nodes)
 	if len(eligibleNodes) == 0 {
-		return nil, errors.New("no eligible nodes found")
+		return model.Node{}, errors.New("no eligible nodes found")
 	}
 	return r.Schedule(eligibleNodes)
 }
 
-func (r RandScheduler) Filter(pod *model.Pod, nodes []*model.Node) []*model.Node {
-	eligibleNodes := make([]*model.Node, 0)
+func (r RandScheduler) Filter(pod model.Pod, nodes []model.Node) []model.Node {
+	eligibleNodes := make([]model.Node, 0)
 	for _, node := range nodes {
 		if node.HasEnoughResourcesForPod(pod) {
 			eligibleNodes = append(eligibleNodes, node)
 		}
 	}
+
 	return eligibleNodes
 }
 
-func (r RandScheduler) Schedule(eligibleNodes []*model.Node) (node *model.Node, err error) {
+func (r RandScheduler) Schedule(eligibleNodes []model.Node) (node model.Node, err error) {
 	return eligibleNodes[rand.Intn(len(eligibleNodes))], nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Scheduler interface {
-	Run(pod *model.Pod, nodes []*model.Node) (node *model.Node, err error)
+	Run(pod model.Pod, nodes []model.Node) (node model.Node, err error)
 }
 
 var S Scheduler

--- a/internal/util/node.go
+++ b/internal/util/node.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"strings"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/utils/strings/slices"
 )
@@ -11,4 +13,9 @@ var MasterNodeName = "uq7g5t611-01"
 func IsNodeOnEdge(nodeKubernetesObject *v1.Node) bool {
 	n := nodeKubernetesObject.GetName()
 	return slices.Contains(edgeNodes, n)
+}
+
+func IsMasterNode(object *v1.Node) bool {
+	nodeName := object.GetName()
+	return strings.Trim(strings.ToLower(nodeName), " ") == strings.Trim(strings.ToLower(MasterNodeName), " ")
 }

--- a/internal/util/resource.go
+++ b/internal/util/resource.go
@@ -1,9 +1,10 @@
 package util
 
 import (
-	"github.com/noisyboy-9/sencillo/internal/model"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/noisyboy-9/sencillo/internal/model"
 )
 
 func RequiredCpuSum(containers []v1.Container) *resource.Quantity {
@@ -21,14 +22,14 @@ func RequiredMemorySum(containers []v1.Container) *resource.Quantity {
 	return result
 }
 
-func GetNodeResourceSum(node *model.Node) *resource.Quantity {
+func GetNodeResourceSum(node model.Node) *resource.Quantity {
 	sum := new(resource.Quantity)
 	sum.Add(*node.Cores)
 	sum.Add(*node.Memory)
 	return sum
 }
 
-func FindSmallestNode(nodes []*model.Node) *model.Node {
+func FindSmallestNode(nodes []model.Node) model.Node {
 	smallestNode := nodes[0]
 	smallestNodeResources := GetNodeResourceSum(smallestNode)
 
@@ -44,7 +45,7 @@ func FindSmallestNode(nodes []*model.Node) *model.Node {
 	return smallestNode
 }
 
-func FindLargestNode(nodes []*model.Node) *model.Node {
+func FindLargestNode(nodes []model.Node) model.Node {
 	biggestNode := nodes[0]
 	biggestNodeResources := GetNodeResourceSum(biggestNode)
 


### PR DESCRIPTION
- **Refactor: don't use or return pointers unless necessary (scheduler pkg)**
- **Refactor: don't use or return pointers unless necessary (util, model, and handler pkg)**
- **Feat: add sync cluster state sync before scheduling**
- **Refactor: simplify connector.Connect() logic**
- **Feat: make sure pods aren't allocated to master node**
- **Feat: remove unnecessary configs**
- **Refactor: final code cleanups**
